### PR TITLE
copyToArray added to RingBuffer + testcases

### DIFF
--- a/waves/src/test/scala/waves/impl/ExamplesSpec.scala
+++ b/waves/src/test/scala/waves/impl/ExamplesSpec.scala
@@ -26,7 +26,6 @@ import waves.Operation.Split
 import waves.{ StreamProducer, Flow }
 
 class ExamplesSpec extends Specification with NoTimeConversions {
-  import scala.concurrent.ExecutionContext.Implicits.global
 
   "The OperationImpl infrastructure must properly execute" >> {
 

--- a/waves/src/test/scala/waves/impl/RingBufferSpec.scala
+++ b/waves/src/test/scala/waves/impl/RingBufferSpec.scala
@@ -1,0 +1,94 @@
+package waves.impl
+
+import org.specs2.mutable.Specification
+import org.specs2.time.NoTimeConversions
+
+/*
+ * Copyright (C) 2015 Debasish Das
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class RingBufferSpec extends Specification with NoTimeConversions {
+  "The RingBuffer implementation" should {
+    "copy all elements from full buffer" in {
+      val buf = new RingBuffer[Int](4)
+      buf.tryEnqueue(2)
+      buf.tryEnqueue(4)
+      buf.tryEnqueue(3)
+      buf.tryEnqueue(5)
+      buf.dequeue()
+      buf.dequeue()
+      buf.tryEnqueue(1)
+      buf.tryEnqueue(7)
+
+      val expected = Array(3.0, 5.0, 1.0, 7.0)
+
+      val dest = Array.fill[Int](4)(0)
+      buf.copyToArray(dest, 0, 4)
+      expected mustEqual dest
+    }
+
+    "copy 50% elements from full buffer" in {
+      val buf = new RingBuffer[Int](4)
+      buf.tryEnqueue(2)
+      buf.tryEnqueue(4)
+      buf.tryEnqueue(3)
+      buf.tryEnqueue(5)
+      buf.dequeue()
+      buf.dequeue()
+      buf.tryEnqueue(1)
+      buf.tryEnqueue(6)
+
+      val dest = Array.fill[Int](2)(0)
+      buf.copyToArray(dest, 2, 2)
+      dest mustEqual Array(1, 6)
+    }
+
+    "copy 50% elements from partially full buffer" in {
+      val buf = new RingBuffer[Int](8)
+      buf.tryEnqueue(2)
+      buf.tryEnqueue(4)
+      buf.tryEnqueue(3)
+      buf.tryEnqueue(5)
+      buf.dequeue()
+      buf.dequeue()
+      buf.tryEnqueue(1)
+      buf.tryEnqueue(6)
+      val dest = Array.fill[Int](2)(0)
+      buf.copyToArray(dest, 2, 2)
+      dest mustEqual Array(1, 6)
+    }
+
+    "copy 67% elements from partially full buffer" in {
+      val buf = new RingBuffer[Int](8)
+      buf.tryEnqueue(2)
+      buf.tryEnqueue(4)
+      buf.tryEnqueue(3)
+      buf.tryEnqueue(5)
+      buf.dequeue()
+      buf.dequeue()
+      buf.tryEnqueue(1)
+      buf.tryEnqueue(6)
+      buf.dequeue()
+      buf.dequeue()
+      buf.tryEnqueue(7)
+      buf.tryEnqueue(8)
+
+      val dest = Array.fill[Int](3)(0)
+      buf.copyToArray(dest, 1, 3)
+      dest mustEqual Array(6, 7, 8)
+    }
+  }
+}
+


### PR DESCRIPTION
@sirthias this closes the issue https://github.com/sirthias/waves/issues/1

I added a TO DO if we can clean up 2 if condition that I don't like. The reason you used mask so that you don't have to call % operator right for wrap around and hopefully mask will take much less time than %.

For streaming algorithms using time series features, it is typical to embed time to run KNN or Neural Net on it and copyToArray operator in RingBuffer helps embed time given the time series feature dimension we choose.

If there are other implementations of RingBuffer in spray / akka-http / reactive streams please let me know and I can add the code over here. Due to runtime requirements I did not use iterator but System.arraycopy.